### PR TITLE
Implement reject/delete endpoints in pedidos

### DIFF
--- a/src/store/services/pedidosApi.js
+++ b/src/store/services/pedidosApi.js
@@ -139,6 +139,22 @@ export const pedidosApi = createApi({
       },
     }),
 
+    // Rechazar un pedido
+    rejectPedido: builder.mutation({
+      query: (id_pedido) => ({
+        url: `/pedidos/${id_pedido}/rechazar`,
+        method: "PUT",
+      }),
+      invalidatesTags: ["Pedidos"],
+      async onQueryStarted(args, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Error al rechazar el pedido:", error);
+        }
+      },
+    }),
+
     // Eliminar un pedido
     deletePedido: builder.mutation({
       query: (id_pedido) => ({
@@ -191,6 +207,7 @@ export const {
   useAsignarPedidoMutation,
   useDesasignarPedidoMutation,
   useDeletePedidoMutation,
+  useRejectPedidoMutation,
   useGetDetalleConTotalQuery,
   useRegistrarDesdePedidoMutation
 } = pedidosApi;


### PR DESCRIPTION
## Summary
- add rejectPedido endpoint to pedidosApi and export hook
- add reject & delete actions to pedidos list with confirmation dialog

## Testing
- `npx eslint src/pages/pedidos/ListarPedidos.jsx` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856498e69d4832c8bacbebd294fbf48