### PR TITLE
Add revert order endpoint and UI action

### DIFF
--- a/src/store/services/pedidosApi.js
+++ b/src/store/services/pedidosApi.js
@@ -155,6 +155,22 @@ export const pedidosApi = createApi({
       },
     }),
 
+    // Revertir un pedido rechazado
+    revertPedido: builder.mutation({
+      query: (id_pedido) => ({
+        url: `/pedidos/${id_pedido}/revertir`,
+        method: "PUT",
+      }),
+      invalidatesTags: ["Pedidos"],
+      async onQueryStarted(args, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Error al revertir el pedido:", error);
+        }
+      },
+    }),
+
     // Eliminar un pedido
     deletePedido: builder.mutation({
       query: (id_pedido) => ({
@@ -208,6 +224,7 @@ export const {
   useDesasignarPedidoMutation,
   useDeletePedidoMutation,
   useRejectPedidoMutation,
+  useRevertPedidoMutation,
   useGetDetalleConTotalQuery,
   useRegistrarDesdePedidoMutation
 } = pedidosApi;


### PR DESCRIPTION
## Summary
- support reverting rejected orders via `/revertir` endpoint
- show **Revertir Pedido** button on list when a pedido is rejected

## Testing
- `npm test` *(fails: no test script)*
